### PR TITLE
Add regexp escape, fix tests in windows env

### DIFF
--- a/bin/doxdox
+++ b/bin/doxdox
@@ -93,6 +93,10 @@ ${chalk.yellow('  -t, --title')}            Sets title.
 
                 fs.writeFileSync(output, content, 'utf8');
 
+                process.stdout.write(`
+                    ${chalk.green('File successfully generated and saved in')}: ${output}
+                `)
+
             } else {
 
                 process.stdout.write(content);

--- a/lib/doxdox.js
+++ b/lib/doxdox.js
@@ -6,6 +6,8 @@ const globby = require('globby');
 
 const loaders = require('./loaders');
 
+const escapeRegExp = require('escape-string-regexp');
+
 const formatPathsArrayToIgnore = require('./utils').formatPathsArrayToIgnore;
 const setConfigDefaults = require('./utils').setConfigDefaults;
 
@@ -15,7 +17,10 @@ const DEFAULT_IGNORE_PATHS = [
     '!./Gulpfile.js'
 ];
 
-const REPLACE_FILENAME_REGEXP = new RegExp(`^(${process.cwd()}/|./)`, 'u');
+/* eslint-disable-next-line */
+console.log(escapeRegExp(process.cwd()));
+
+const REPLACE_FILENAME_REGEXP = new RegExp(`^(${escapeRegExp(process.cwd())}/|./)`, 'u');
 
 /**
  * Parse a file with custom parser.

--- a/lib/doxdox.js
+++ b/lib/doxdox.js
@@ -4,9 +4,9 @@ const fs = require('fs');
 
 const globby = require('globby');
 
-const loaders = require('./loaders');
-
 const escapeRegExp = require('escape-string-regexp');
+
+const loaders = require('./loaders');
 
 const formatPathsArrayToIgnore = require('./utils').formatPathsArrayToIgnore;
 const setConfigDefaults = require('./utils').setConfigDefaults;
@@ -16,9 +16,6 @@ const DEFAULT_IGNORE_PATHS = [
     '!./Gruntfile.js',
     '!./Gulpfile.js'
 ];
-
-/* eslint-disable-next-line */
-console.log(escapeRegExp(process.cwd()));
 
 const REPLACE_FILENAME_REGEXP = new RegExp(`^(${escapeRegExp(process.cwd())}/|./)`, 'u');
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "doxdox-plugin-bootstrap": "~2.0.0",
     "doxdox-plugin-handlebars": "~2.0.0",
     "doxdox-plugin-markdown": "~2.0.0",
+    "escape-string-regexp": "^1.0.5",
     "globby": "9.0.0",
     "parse-cmd-args": "2.0.0",
     "update-notifier": "2.5.0"

--- a/test/specs/doxdox.js
+++ b/test/specs/doxdox.js
@@ -1,5 +1,6 @@
 const assert = require('assert');
 const fs = require('fs');
+const os = require('os');
 
 const doxdox = require('../../lib/doxdox');
 
@@ -36,9 +37,11 @@ describe('doxdox', () => {
                 })
                 .then(content => {
 
-                    assert.equal(
+                    assert.strictEqual(
                         content,
                         fs.readFileSync('./test/fixtures/doxdox.md', 'utf8')
+                            .split(os.EOL)
+                            .join('\n')
                     );
 
                 }));
@@ -58,9 +61,11 @@ describe('doxdox', () => {
                 })
                 .then(content => {
 
-                    assert.equal(
+                    assert.strictEqual(
                         content,
                         fs.readFileSync('./test/fixtures/doxdox.md', 'utf8')
+                            .split(os.EOL)
+                            .join('\n')
                     );
 
                 }));


### PR DESCRIPTION
Hello @neogeek !

When trying to use `doxdox` in one of my projects I came across with a problem related with one of RegExp's being unescaped (clearly Windows environment fault) so this PR fixes it by escaping the `process.cwd()` using another package I looked into for this case, also at the tests I replaced the `assert.equal` method, which I noted that was deprecated in favor to `assert.strictEqual`, with `assert.strictEqual` and added some normalization after `readFileSync` so it can deal with different types of EOL to enforce test stability in different envs.