### PR TITLE
Replace backslashes on Windows

### DIFF
--- a/lib/doxdox.js
+++ b/lib/doxdox.js
@@ -15,6 +15,11 @@ const DEFAULT_IGNORE_PATHS = [
     '!./Gulpfile.js'
 ];
 
+let currentDirectory = process.cwd();
+if (process.platform==='win32') {
+    currentDirectory = currentDirectory.replace(/\\/g,'/');
+}
+
 const REPLACE_FILENAME_REGEXP = new RegExp(`^(${process.cwd()}/|./)`, 'u');
 
 /**


### PR DESCRIPTION
On Windows the RegEx throws an error `Invalid regular expression: ...: Invalid escape`