### PR TITLE
[hotfix] Make directory before rendering output.

### DIFF
--- a/packages/doxdox-cli/src/index.ts
+++ b/packages/doxdox-cli/src/index.ts
@@ -137,6 +137,8 @@ const overridePackage = args.flags['-p'] || args.flags['--package'];
     });
 
     if (overrideOutput) {
+        await fs.mkdir(dirname(overrideOutput), { recursive: true });
+
         await fs.writeFile(overrideOutput, output);
     } else {
         process.stdout.write(output);


### PR DESCRIPTION
Fixed an issue where output would fail if the output directory did not exist.