### PR TITLE
Fix findParentNodeModules failing on paths with non-URI legal chars

### DIFF
--- a/packages/doxdox-cli/src/index.ts
+++ b/packages/doxdox-cli/src/index.ts
@@ -6,6 +6,8 @@ import { promises as fs } from 'fs';
 
 import { dirname, join } from 'path';
 
+import { fileURLToPath } from 'url';
+
 import { globby } from 'globby';
 
 import updateNotifier from 'update-notifier';
@@ -19,8 +21,7 @@ import doxdox, {
     getRootDirPath,
     loadPlugin,
     parseConfigFromCLI,
-    parseIgnoreConfig,
-    sanitizePath
+    parseIgnoreConfig
 } from 'doxdox-core';
 
 import { Doc, File } from 'doxdox-core';
@@ -113,7 +114,7 @@ const overridePackage = String(
     const cliConfig = parseConfigFromCLI(args.raw);
 
     const nodeModulesDir = await findParentNodeModules(
-        dirname(sanitizePath(import.meta.url))
+        dirname(fileURLToPath(import.meta.url))
     );
 
     if (!nodeModulesDir) {

--- a/packages/doxdox-core/src/utils.test.ts
+++ b/packages/doxdox-core/src/utils.test.ts
@@ -10,8 +10,7 @@ import {
     isDirectory,
     isFile,
     parseConfigFromCLI,
-    parseIgnoreConfig,
-    sanitizePath,
+    parseIgnoreConfig
     slugify
 } from './utils';
 
@@ -166,18 +165,6 @@ describe('utils', () => {
         });
         it('parse ignore config with empty contents', () => {
             expect(parseIgnoreConfig('')).toEqual([]);
-        });
-    });
-
-    describe('sanitizePath', () => {
-        it('sanitize path', () => {
-            expect(
-                sanitizePath(
-                    'file:///Users/scottdoxey/git/github/doxdox/packages/doxdox-cli/dist/src/index.js'
-                )
-            ).toEqual(
-                '/Users/scottdoxey/git/github/doxdox/packages/doxdox-cli/dist/src/index.js'
-            );
         });
     });
 

--- a/packages/doxdox-core/src/utils.test.ts
+++ b/packages/doxdox-core/src/utils.test.ts
@@ -10,7 +10,7 @@ import {
     isDirectory,
     isFile,
     parseConfigFromCLI,
-    parseIgnoreConfig
+    parseIgnoreConfig,
     slugify
 } from './utils';
 

--- a/packages/doxdox-core/src/utils.ts
+++ b/packages/doxdox-core/src/utils.ts
@@ -192,16 +192,6 @@ export const parseIgnoreConfig = (contents: string): string[] =>
         .map(line => `!${line.trim().replace(/^!/, '')}`);
 
 /**
- * Sanitizes given path or url.
- *
- * @param {string} [url] Path or url.
- * @return {Promise<string>} Sanitized path.
- * @public
- */
-
-export const sanitizePath = (path: string): string => new URL(path).pathname;
-
-/**
  * Slugify a value for use as an anchor.
  *
  * @return {string} Contents to slugify.


### PR DESCRIPTION
The `sanitizePath` function does not resolve percent encoded path characters, returning a path like `/my/path to/dir` as `/my/path%20to/dir`, which in turn makes `findParentNodeModules` fail on such paths.

The solution is to use Node’s [`fileURLToPath`](https://nodejs.org/api/url.html#urlfileurltopathurl) instead. As that function’s signature is identical to `sanitizePath` and the only call site of the latter is inside `findParentNodeModules`, I’ve opted for removing `sanitizePath` entirely, but if you prefer the indirection, redefining it as an alias to `fileURLToPath` should be fine.

~~Apologies for the granular commits, but this was a quick hack in GitHub’s online commit interface.~~